### PR TITLE
remove brackets

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -73,7 +73,7 @@ export const activitywatch_run_query_tool = {
       
       // Format queries
       let queryString = args.query.join(' ');
-      const formattedQueries = [[queryString]];
+      const formattedQueries = [queryString];
 
       // Set up query data
       const queryData = {


### PR DESCRIPTION
the request body to the /query endpoint was invalid due to using
string[][] instead of string[]

The query tool was failing with 400 bad request