### PR TITLE
feat: add category management and uncategorized event discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,10 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Claude Code local files (machine-specific)
+.claude/
+CLAUDE.md
+
+# Local MCP server config (contains absolute local paths)
+.mcp.json

--- a/src/categories.ts
+++ b/src/categories.ts
@@ -1,0 +1,275 @@
+import axios from 'axios';
+import { AW_API_BASE } from "./config.js";
+
+export interface Category {
+  name: string[];
+  rule: {
+    type: "regex" | "none";
+    regex?: string;
+    ignore_case?: boolean;
+  };
+  data?: {
+    color?: string;
+    score?: number;
+  };
+}
+
+// ─── GET CATEGORIES ───────────────────────────────────────────────────────────
+
+export const activitywatch_get_categories_tool = {
+  name: "activitywatch_get_categories",
+  description: "Get all ActivityWatch categories (classification rules). Returns the list of categories with their regex rules used to classify window events.",
+  inputSchema: {
+    type: "object",
+    properties: {}
+  },
+
+  handler: async (_args: Record<string, never>) => {
+    try {
+      const response = await axios.get(`${AW_API_BASE}/settings/classes`);
+      const categories: Category[] = response.data ?? [];
+      return {
+        content: [{ type: "text", text: JSON.stringify(categories, null, 2) }]
+      };
+    } catch (error) {
+      return handleError("fetch categories", error);
+    }
+  }
+};
+
+// ─── ADD CATEGORY ─────────────────────────────────────────────────────────────
+
+export const activitywatch_add_category_tool = {
+  name: "activitywatch_add_category",
+  description: "Add a new category to ActivityWatch. The category will be appended to the existing list.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "array",
+        items: { type: "string" },
+        description: "Category name hierarchy, e.g. [\"Work\", \"Programming\"]",
+        minItems: 1
+      },
+      regex: {
+        type: "string",
+        description: "Regex pattern to match app names / window titles (pipe-separated for OR). Required unless rule_type is 'none'."
+      },
+      ignore_case: {
+        type: "boolean",
+        description: "Whether the regex match is case-insensitive (default: true)"
+      },
+      rule_type: {
+        type: "string",
+        enum: ["regex", "none"],
+        description: "Rule type: 'regex' (default) or 'none' for parent-only categories"
+      },
+      color: {
+        type: "string",
+        description: "Optional hex color for the category, e.g. '#FF0000'"
+      },
+      score: {
+        type: "number",
+        description: "Optional productivity score for the category"
+      }
+    },
+    required: ["name"]
+  },
+
+  handler: async (args: {
+    name: string[];
+    regex?: string;
+    ignore_case?: boolean;
+    rule_type?: "regex" | "none";
+    color?: string;
+    score?: number;
+  }) => {
+    try {
+      const existing: Category[] = (await axios.get(`${AW_API_BASE}/settings/classes`)).data ?? [];
+
+      const rule_type = args.rule_type ?? (args.regex ? "regex" : "none");
+      const newCategory: Category = {
+        name: args.name,
+        rule: {
+          type: rule_type,
+          ...(rule_type === "regex" && args.regex ? { regex: args.regex } : {}),
+          ...(rule_type === "regex" ? { ignore_case: args.ignore_case ?? true } : {})
+        }
+      };
+
+      if (args.color || args.score !== undefined) {
+        newCategory.data = {};
+        if (args.color) newCategory.data.color = args.color;
+        if (args.score !== undefined) newCategory.data.score = args.score;
+      }
+
+      await axios.post(`${AW_API_BASE}/settings/classes`, [...existing, newCategory]);
+
+      return {
+        content: [{
+          type: "text",
+          text: `Category "${args.name.join(" > ")}" added successfully.\n${JSON.stringify(newCategory, null, 2)}`
+        }]
+      };
+    } catch (error) {
+      return handleError("add category", error);
+    }
+  }
+};
+
+// ─── UPDATE CATEGORY ──────────────────────────────────────────────────────────
+
+export const activitywatch_update_category_tool = {
+  name: "activitywatch_update_category",
+  description: "Update an existing ActivityWatch category by its name path. Replaces the matching category with new values.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "array",
+        items: { type: "string" },
+        description: "Name path of the category to update, e.g. [\"Work\", \"Programming\"]",
+        minItems: 1
+      },
+      regex: {
+        type: "string",
+        description: "New regex pattern"
+      },
+      ignore_case: {
+        type: "boolean",
+        description: "Whether the regex is case-insensitive"
+      },
+      rule_type: {
+        type: "string",
+        enum: ["regex", "none"],
+        description: "Rule type"
+      },
+      color: {
+        type: "string",
+        description: "Optional hex color"
+      },
+      score: {
+        type: "number",
+        description: "Optional productivity score"
+      }
+    },
+    required: ["name"]
+  },
+
+  handler: async (args: {
+    name: string[];
+    regex?: string;
+    ignore_case?: boolean;
+    rule_type?: "regex" | "none";
+    color?: string;
+    score?: number;
+  }) => {
+    try {
+      const existing: Category[] = (await axios.get(`${AW_API_BASE}/settings/classes`)).data ?? [];
+      const idx = existing.findIndex(c => JSON.stringify(c.name) === JSON.stringify(args.name));
+
+      if (idx === -1) {
+        return {
+          content: [{
+            type: "text",
+            text: `Category "${args.name.join(" > ")}" not found.`
+          }],
+          isError: true
+        };
+      }
+
+      const existing_cat = existing[idx];
+      const rule_type = args.rule_type ?? existing_cat.rule.type;
+      const updated: Category = {
+        name: args.name,
+        rule: {
+          type: rule_type,
+          ...(rule_type === "regex"
+            ? {
+                regex: args.regex ?? existing_cat.rule.regex,
+                ignore_case: args.ignore_case ?? existing_cat.rule.ignore_case ?? true
+              }
+            : {})
+        }
+      };
+
+      if (args.color || args.score !== undefined || existing_cat.data) {
+        updated.data = { ...existing_cat.data };
+        if (args.color) updated.data!.color = args.color;
+        if (args.score !== undefined) updated.data!.score = args.score;
+      }
+
+      const updated_list = [...existing];
+      updated_list[idx] = updated;
+      await axios.post(`${AW_API_BASE}/settings/classes`, updated_list);
+
+      return {
+        content: [{
+          type: "text",
+          text: `Category "${args.name.join(" > ")}" updated.\n${JSON.stringify(updated, null, 2)}`
+        }]
+      };
+    } catch (error) {
+      return handleError("update category", error);
+    }
+  }
+};
+
+// ─── DELETE CATEGORY ──────────────────────────────────────────────────────────
+
+export const activitywatch_delete_category_tool = {
+  name: "activitywatch_delete_category",
+  description: "Delete an ActivityWatch category by its name path.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "array",
+        items: { type: "string" },
+        description: "Name path of the category to delete, e.g. [\"Work\", \"Programming\"]",
+        minItems: 1
+      }
+    },
+    required: ["name"]
+  },
+
+  handler: async (args: { name: string[] }) => {
+    try {
+      const existing: Category[] = (await axios.get(`${AW_API_BASE}/settings/classes`)).data ?? [];
+      const filtered = existing.filter(c => JSON.stringify(c.name) !== JSON.stringify(args.name));
+
+      if (filtered.length === existing.length) {
+        return {
+          content: [{
+            type: "text",
+            text: `Category "${args.name.join(" > ")}" not found.`
+          }],
+          isError: true
+        };
+      }
+
+      await axios.post(`${AW_API_BASE}/settings/classes`, filtered);
+      return {
+        content: [{
+          type: "text",
+          text: `Category "${args.name.join(" > ")}" deleted successfully.`
+        }]
+      };
+    } catch (error) {
+      return handleError("delete category", error);
+    }
+  }
+};
+
+// ─── SHARED ERROR HANDLER ─────────────────────────────────────────────────────
+
+function handleError(operation: string, error: unknown) {
+  if (axios.isAxiosError(error)) {
+    const msg = error.response
+      ? `Failed to ${operation}: ${error.message} (Status: ${error.response.status})\n${JSON.stringify(error.response.data)}`
+      : `Failed to ${operation}: ${error.message}\nIs ActivityWatch running at http://localhost:5600?`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+  const msg = error instanceof Error ? error.message : String(error);
+  return { content: [{ type: "text", text: `Failed to ${operation}: ${msg}` }], isError: true };
+}

--- a/src/categories.ts
+++ b/src/categories.ts
@@ -263,7 +263,7 @@ export const activitywatch_delete_category_tool = {
 
 // ─── SHARED ERROR HANDLER ─────────────────────────────────────────────────────
 
-function handleError(operation: string, error: unknown) {
+export function handleError(operation: string, error: unknown) {
   if (axios.isAxiosError(error)) {
     const msg = error.response
       ? `Failed to ${operation}: ${error.message} (Status: ${error.response.status})\n${JSON.stringify(error.response.data)}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,28 @@ import { activitywatch_get_events_tool } from "./rawEvents.js";
 import { activitywatch_query_examples_tool } from "./queryExamples.js";
 import { activitywatch_get_settings_tool } from "./getSettings.js";
 import { AW_API_BASE } from "./config.js";
+import {
+  activitywatch_get_categories_tool,
+  activitywatch_add_category_tool,
+  activitywatch_update_category_tool,
+  activitywatch_delete_category_tool
+} from "./categories.js";
+import { activitywatch_get_uncategorized_events_tool } from "./uncategorizedEvents.js";
 
 // Populate the VERSION constant from package.json
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const packageJson = require('../package.json');
 const VERSION = packageJson.version;
+
+// Parse a value that may be an array or a JSON-encoded array string
+function parseArray(val: any): string[] {
+  if (Array.isArray(val)) return val;
+  if (typeof val === 'string') {
+    try { const parsed = JSON.parse(val); if (Array.isArray(parsed)) return parsed; } catch {}
+  }
+  return [];
+}
 
 // Helper function to handle type-safe tool responses
 const makeSafeToolResponse = (handler: Function) => async (...args: any[]) => {
@@ -72,6 +88,31 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: activitywatch_get_settings_tool.name,
         description: activitywatch_get_settings_tool.description,
         inputSchema: activitywatch_get_settings_tool.inputSchema
+      },
+      {
+        name: activitywatch_get_categories_tool.name,
+        description: activitywatch_get_categories_tool.description,
+        inputSchema: activitywatch_get_categories_tool.inputSchema
+      },
+      {
+        name: activitywatch_get_uncategorized_events_tool.name,
+        description: activitywatch_get_uncategorized_events_tool.description,
+        inputSchema: activitywatch_get_uncategorized_events_tool.inputSchema
+      },
+      {
+        name: activitywatch_add_category_tool.name,
+        description: activitywatch_add_category_tool.description,
+        inputSchema: activitywatch_add_category_tool.inputSchema
+      },
+      {
+        name: activitywatch_update_category_tool.name,
+        description: activitywatch_update_category_tool.description,
+        inputSchema: activitywatch_update_category_tool.inputSchema
+      },
+      {
+        name: activitywatch_delete_category_tool.name,
+        description: activitywatch_delete_category_tool.description,
+        inputSchema: activitywatch_delete_category_tool.inputSchema
       }
     ]
   };
@@ -271,9 +312,39 @@ but may need additional configuration.
       end: typeof args.end === 'string' ? args.end : undefined
     });
   } else if (request.params.name === activitywatch_get_settings_tool.name) {
-    // For the settings tool
     return makeSafeToolResponse(activitywatch_get_settings_tool.handler)({
       key: typeof args.key === 'string' ? args.key : undefined
+    });
+  } else if (request.params.name === activitywatch_get_categories_tool.name) {
+    return makeSafeToolResponse(activitywatch_get_categories_tool.handler)({});
+  } else if (request.params.name === activitywatch_get_uncategorized_events_tool.name) {
+    return makeSafeToolResponse(activitywatch_get_uncategorized_events_tool.handler)({
+      start: typeof args.start === 'string' ? args.start : undefined,
+      end: typeof args.end === 'string' ? args.end : undefined,
+      limit: typeof args.limit === 'number' ? args.limit : undefined,
+      min_seconds: typeof args.min_seconds === 'number' ? args.min_seconds : undefined
+    });
+  } else if (request.params.name === activitywatch_add_category_tool.name) {
+    return makeSafeToolResponse(activitywatch_add_category_tool.handler)({
+      name: parseArray(args.name),
+      regex: typeof args.regex === 'string' ? args.regex : undefined,
+      ignore_case: typeof args.ignore_case === 'boolean' ? args.ignore_case : undefined,
+      rule_type: args.rule_type === 'none' ? 'none' : args.rule_type === 'regex' ? 'regex' : undefined,
+      color: typeof args.color === 'string' ? args.color : undefined,
+      score: typeof args.score === 'number' ? args.score : undefined
+    });
+  } else if (request.params.name === activitywatch_update_category_tool.name) {
+    return makeSafeToolResponse(activitywatch_update_category_tool.handler)({
+      name: parseArray(args.name),
+      regex: typeof args.regex === 'string' ? args.regex : undefined,
+      ignore_case: typeof args.ignore_case === 'boolean' ? args.ignore_case : undefined,
+      rule_type: args.rule_type === 'none' ? 'none' : args.rule_type === 'regex' ? 'regex' : undefined,
+      color: typeof args.color === 'string' ? args.color : undefined,
+      score: typeof args.score === 'number' ? args.score : undefined
+    });
+  } else if (request.params.name === activitywatch_delete_category_tool.name) {
+    return makeSafeToolResponse(activitywatch_delete_category_tool.handler)({
+      name: Array.isArray(args.name) ? args.name : []
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,7 +344,7 @@ but may need additional configuration.
     });
   } else if (request.params.name === activitywatch_delete_category_tool.name) {
     return makeSafeToolResponse(activitywatch_delete_category_tool.handler)({
-      name: Array.isArray(args.name) ? args.name : []
+      name: parseArray(args.name)
     });
   }
 

--- a/src/uncategorizedEvents.ts
+++ b/src/uncategorizedEvents.ts
@@ -123,12 +123,14 @@ export const activitywatch_get_uncategorized_events_tool = {
         }
       }
 
-      const results: UncategorizedSummary[] = Array.from(map.values())
+      const allUncategorized = Array.from(map.values());
+      // Compute total before filtering/slicing so the label reflects the true uncategorized time
+      const totalUncategorized = allUncategorized.reduce((s, e) => s + e.duration_seconds, 0);
+
+      const results: UncategorizedSummary[] = allUncategorized
         .filter(e => e.duration_seconds >= min_seconds)
         .sort((a, b) => b.duration_seconds - a.duration_seconds)
         .slice(0, limit);
-
-      const totalUncategorized = results.reduce((s, e) => s + e.duration_seconds, 0);
 
       const text = [
         `Uncategorized events: ${start.toISOString().slice(0, 10)} → ${end.toISOString().slice(0, 10)}`,

--- a/src/uncategorizedEvents.ts
+++ b/src/uncategorizedEvents.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { AW_API_BASE } from "./config.js";
+import { handleError } from './categories.js';
 
 export interface UncategorizedSummary {
   app: string;
@@ -155,14 +156,7 @@ export const activitywatch_get_uncategorized_events_tool = {
         ]
       };
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        const msg = error.response
-          ? `Failed to fetch uncategorized events: ${error.message} (Status: ${error.response.status})\n${JSON.stringify(error.response.data)}`
-          : `Failed to fetch uncategorized events: ${error.message}\nIs ActivityWatch running at http://localhost:5600?`;
-        return { content: [{ type: "text", text: msg }], isError: true };
-      }
-      const msg = error instanceof Error ? error.message : String(error);
-      return { content: [{ type: "text", text: `Failed to fetch uncategorized events: ${msg}` }], isError: true };
+      return handleError("fetch uncategorized events", error);
     }
   }
 };

--- a/src/uncategorizedEvents.ts
+++ b/src/uncategorizedEvents.ts
@@ -1,0 +1,165 @@
+import axios from 'axios';
+import { AW_API_BASE } from "./config.js";
+
+export interface UncategorizedSummary {
+  app: string;
+  title: string;
+  duration_seconds: number;
+}
+
+interface Category {
+  name: string[];
+  rule: { type: string; regex?: string; ignore_case?: boolean };
+}
+
+/**
+ * Client-side categorization: returns true if the event matches any category rule.
+ */
+function matchesAnyCategory(app: string, title: string, categories: Category[]): boolean {
+  const combined = `${app} ${title}`;
+  for (const cat of categories) {
+    if (cat.rule.type !== "regex" || !cat.rule.regex) continue;
+    try {
+      const flags = cat.rule.ignore_case !== false ? "i" : "";
+      const re = new RegExp(cat.rule.regex, flags);
+      if (re.test(combined)) return true;
+    } catch {
+      // skip invalid regex
+    }
+  }
+  return false;
+}
+
+export const activitywatch_get_uncategorized_events_tool = {
+  name: "activitywatch_get_uncategorized_events",
+  description:
+    "Fetch window events that have NOT been matched by any category rule, grouped and sorted by total duration. " +
+    "Use this to discover what activities need new category rules. " +
+    "Returns the top N app+title combinations by time spent.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      start: {
+        type: "string",
+        description: "Start of the time range in ISO format, e.g. '2024-01-01'. Defaults to 30 days ago."
+      },
+      end: {
+        type: "string",
+        description: "End of the time range in ISO format, e.g. '2024-12-31'. Defaults to now."
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of distinct app+title combinations to return, sorted by duration (default: 50)"
+      },
+      min_seconds: {
+        type: "number",
+        description: "Only include combinations with at least this many seconds of total activity (default: 30)"
+      }
+    }
+  },
+
+  handler: async (args: {
+    start?: string;
+    end?: string;
+    limit?: number;
+    min_seconds?: number;
+  }) => {
+    try {
+      const limit = args.limit ?? 50;
+      const min_seconds = args.min_seconds ?? 30;
+
+      const end = args.end ? new Date(args.end) : new Date();
+      const start = args.start
+        ? new Date(args.start)
+        : new Date(end.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+      const timeperiod = `${start.toISOString().slice(0, 10)}/${end.toISOString().slice(0, 10)}`;
+
+      // Fetch categories for client-side filtering
+      let categories: Category[] = [];
+      try {
+        const resp = await axios.get(`${AW_API_BASE}/settings/classes`);
+        categories = resp.data ?? [];
+      } catch {
+        // proceed without categories — all events will be shown
+      }
+
+      // Simple query: all window events (no AFK filter to avoid version issues)
+      const query = `events = query_bucket(find_bucket("aw-watcher-window_")); RETURN = events;`;
+
+      const response = await axios.post(`${AW_API_BASE}/query/`, {
+        query: [query],
+        timeperiods: [timeperiod]
+      });
+
+      const rawEvents: any[] = Array.isArray(response.data?.[0])
+        ? response.data[0]
+        : (response.data?.[0]?.events ?? []);
+
+      // Aggregate by app + title, filtering out categorized events client-side
+      const map = new Map<string, UncategorizedSummary>();
+      let totalAll = 0;
+
+      for (const ev of rawEvents) {
+        const app: string = ev.data?.app ?? "(unknown)";
+        const title: string = ev.data?.title ?? "";
+        const duration: number = ev.duration ?? 0;
+        totalAll += duration;
+
+        if (matchesAnyCategory(app, title, categories)) continue;
+
+        const key = `${app}\x00${title}`;
+        const existing = map.get(key);
+        if (existing) {
+          existing.duration_seconds += duration;
+        } else {
+          map.set(key, { app, title, duration_seconds: duration });
+        }
+      }
+
+      const results: UncategorizedSummary[] = Array.from(map.values())
+        .filter(e => e.duration_seconds >= min_seconds)
+        .sort((a, b) => b.duration_seconds - a.duration_seconds)
+        .slice(0, limit);
+
+      const totalUncategorized = results.reduce((s, e) => s + e.duration_seconds, 0);
+
+      const text = [
+        `Uncategorized events: ${start.toISOString().slice(0, 10)} → ${end.toISOString().slice(0, 10)}`,
+        `Total active time: ${formatDuration(totalAll)}`,
+        `Uncategorized time: ${formatDuration(totalUncategorized)}`,
+        `Existing categories applied: ${categories.length}`,
+        `Showing top ${results.length} uncategorized app+title pairs (min ${min_seconds}s):`,
+        "",
+        ...results.map((r, i) =>
+          `${i + 1}. [${formatDuration(r.duration_seconds)}] ${r.app} — ${r.title || "(no title)"}`
+        )
+      ].join("\n");
+
+      return {
+        content: [
+          { type: "text", text },
+          { type: "text", text: "\n\nRaw JSON:\n" + JSON.stringify(results, null, 2) }
+        ]
+      };
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const msg = error.response
+          ? `Failed to fetch uncategorized events: ${error.message} (Status: ${error.response.status})\n${JSON.stringify(error.response.data)}`
+          : `Failed to fetch uncategorized events: ${error.message}\nIs ActivityWatch running at http://localhost:5600?`;
+        return { content: [{ type: "text", text: msg }], isError: true };
+      }
+      const msg = error instanceof Error ? error.message : String(error);
+      return { content: [{ type: "text", text: `Failed to fetch uncategorized events: ${msg}` }], isError: true };
+    }
+  }
+};
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}

--- a/src/uncategorizedEvents.ts
+++ b/src/uncategorizedEvents.ts
@@ -16,6 +16,10 @@ interface Category {
  * Client-side categorization: returns true if the event matches any category rule.
  */
 function matchesAnyCategory(app: string, title: string, categories: Category[]): boolean {
+  // NOTE: AW's own categorization engine tests the regex against the `app` and `title` fields
+  // individually. Here we test against a single concatenated "app title" string for simplicity.
+  // This means a regex like "chrome gmail" would match here but not in the AW UI — a subtle
+  // semantic difference that can cause minor discrepancies in what gets flagged as uncategorized.
   const combined = `${app} ${title}`;
   for (const cat of categories) {
     if (cat.rule.type !== "regex" || !cat.rule.regex) continue;

--- a/src/uncategorizedEvents.ts
+++ b/src/uncategorizedEvents.ts
@@ -84,8 +84,14 @@ export const activitywatch_get_uncategorized_events_tool = {
         // proceed without categories — all events will be shown
       }
 
-      // Simple query: all window events (no AFK filter to avoid version issues)
-      const query = `events = query_bucket(find_bucket("aw-watcher-window_")); RETURN = events;`;
+      // Query window events filtered by non-AFK periods (standard AW pattern, works across versions)
+      const query = [
+        `window_events = query_bucket(find_bucket("aw-watcher-window_"));`,
+        `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));`,
+        `not_afk = filter_keyvals(afk_events, "status", ["not-afk"]);`,
+        `events = filter_period_intersect(window_events, not_afk);`,
+        `RETURN = events;`
+      ].join(" ");
 
       const response = await axios.post(`${AW_API_BASE}/query/`, {
         query: [query],


### PR DESCRIPTION
## Summary

This PR adds five new MCP tools that enable LLMs to manage ActivityWatch categories and discover what activity is going uncategorized.

### New tools

- **`activitywatch_get_categories`** — reads the full list of current category rules from `GET /api/0/settings/classes`
- **`activitywatch_get_uncategorized_events`** — fetches active window events for a given time range, applies existing category rules client-side, and returns the top uncategorized `app + window title` pairs sorted by total duration
- **`activitywatch_add_category`** — appends a new category with a regex rule
- **`activitywatch_update_category`** — updates an existing category matched by name path
- **`activitywatch_delete_category`** — removes a category by name path

All category tools read/write via `POST /api/0/settings/classes` (full array replace, consistent with how the AW web UI operates).

### Why client-side categorization in `get_uncategorized_events`

The AW query language's `categorize()` function does not accept an inline JSON array — it expects categories pre-loaded server-side. To avoid that limitation and stay compatible across AW versions, the tool fetches raw window events via a simple AQL query and applies JS regex matching locally.

### Also included

- `.gitignore` additions for `.claude/` (Claude Code session files) and `.mcp.json` (local MCP config with machine-specific paths)

## How to use

```
1. "Show me my top uncategorized activities from the last 30 days"
   → activitywatch_get_uncategorized_events

2. "What categories do I already have?"
   → activitywatch_get_categories

3. "Add a category Work > Development for VS Code"
   → activitywatch_add_category { name: ["Work","Development"], regex: "Visual Studio Code" }

4. "Update the Games category to also include Steam"
   → activitywatch_update_category

5. "Delete the category Work > Audio"
   → activitywatch_delete_category
```

## Test plan

- [x] `activitywatch_get_categories` returns existing categories array
- [x] `activitywatch_get_uncategorized_events` returns ranked list of app+title pairs not matched by any rule
- [x] `activitywatch_add_category` appends a new entry visible in subsequent `get_categories` calls
- [x] `activitywatch_update_category` modifies the correct entry by name path
- [x] `activitywatch_delete_category` removes the correct entry
- [x] `.mcp.json` and `.claude/` are not tracked by git

🤖 Generated with [Claude Code](https://claude.ai/claude-code)